### PR TITLE
Fix headers not toggling when certain combinations of teams are selected

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,13 +104,11 @@ const render = () => {
             content += '</div>';
             display.innerHTML += content;
         }
-        [...display.querySelectorAll('.teams')].forEach(div => {
-            const header = div.querySelector('h3');
-            header.addEventListener('click', () => {
-                div.classList.toggle('closed');
-            });
-        });
     }
+    [...display.querySelectorAll('.teams')].forEach(div => {
+        const header = div.querySelector('h3');
+        header.addEventListener('click', () => div.classList.toggle('closed'));
+    });
 };
 const getSaveJson = () => JSON.stringify({ caught, teams, required });
 saveBtn.addEventListener('click', () => {


### PR DESCRIPTION
Only attach event listeners outside of loop, not multiple times -- if we attach once per calculated team (as it was before), then an even number of teams (valid or invalid) causes the event to toggle off and back on immediately.